### PR TITLE
Enhance emails

### DIFF
--- a/src/common/email_job.py
+++ b/src/common/email_job.py
@@ -11,11 +11,11 @@ KEY = os.environ.get("SENDGRID_KEY")
 
 class EmailJob():
     @staticmethod
-    def send_email(products: list[Product], recipient: str):
+    def send_urgent(products: list[Product], recipient: str):
         message = Mail(
             from_email=APP_EMAIL,
             to_emails=recipient,
-            subject='Inventory is running low!',
+            subject='URGENT! Inventory is almost out!',
             html_content = f'<strong>The following products are at or below 1/4 of their ideal stock!</strong> \
                  <ul> \
                  {''.join([f"<li>{p.product_name}</li>" for p in products])} \
@@ -25,16 +25,37 @@ class EmailJob():
             response = sg.send(message)
             print(response.status_code)
         except Exception as e:
-            print(e.message)
+            print(e)
+
+    @staticmethod
+    def send_warning(products: list[Product], recipient: str):
+        message = Mail(
+            from_email=APP_EMAIL,
+            to_emails=recipient,
+            subject='Warning! Inventory is running low!',
+            html_content = f'<strong>The following products are at or below 1/2 of their ideal stock!</strong> \
+                 <ul> \
+                 {''.join([f"<li>{p.product_name}</li>" for p in products])} \
+                 </ul>')
+        try:
+            sg = SendGridAPIClient(KEY)
+            response = sg.send(message)
+            print(response.status_code)
+        except Exception as e:
+            print(e)
 
     @staticmethod
     def process_emails(admin_email: str):
         if admin_email and len(admin_email) > 0:
-            products = Product.products_leq_quarter()
-            if len(products) > 0:
-                EmailJob.send_email(products, admin_email)
-                for item in products:
-                    item.mark_notified()
-
+            warnings = Product.products_leq_half()
+            if len(warnings) > 0:
+                EmailJob.send_warning(warnings, admin_email)
+                for product in warnings:
+                    product.increment_notified()
+            urgents = Product.products_leq_quarter()
+            if len(urgents) > 0:
+                EmailJob.send_urgent(urgents, admin_email)
+                for product in urgents:
+                    product.increment_notified()
 
 

--- a/src/model/product.py
+++ b/src/model/product.py
@@ -46,7 +46,10 @@ class Product(Model):
     image_path = CharField(null=True)
     last_updated = DateTimeField(default=datetime.datetime.now)
     days_left = DecimalField(decimal_places=2, auto_round=True, null=True)
-    notified = BooleanField(default=False)
+    #not notified = 0
+    #notified once (half inventory) = 1
+    #notified twice (half and 1/4 inventory) = 2
+    notified = IntegerField(default=0)
 
     ########################################
     ############# CLASS METHODS ############
@@ -108,7 +111,17 @@ class Product(Model):
         products = Product.all()
         res = []
         for item in products:
-            if not item.notified and item.inventory <= (item.ideal_stock / 4):
+            if item.notified < 2 and item.inventory <= (item.ideal_stock / 4):
+                res.append(item)
+        return res
+    
+    #retrieves products with inventory <= 50% ideal stock
+    @staticmethod
+    def products_leq_half() -> list['Product']:
+        products = Product.all()
+        res = []
+        for item in products:
+            if item.notified < 1 and item.inventory <= (item.ideal_stock / 2):
                 res.append(item)
         return res
 
@@ -201,12 +214,12 @@ class Product(Model):
         self.save()
 
     #marks product as notified (after email is sent)
-    def mark_notified(self):
-        self.notified = True
+    def increment_notified(self):
+        self.notified += 1
         self.save()
     
     def mark_not_notified(self):
-        self.notified = False
+        self.notified = 0 
         self.save()
 
         


### PR DESCRIPTION
# What does this PR implement/fix? Explain your changes.

The client stated that she wanted email notifications when products reach 50% inventory as well as 25% inventory. Here it is. 

# Does this close any open issues?

Closes #49

# Instructions for testing

NOTE: You will probably have to delete your database

1. Click the `ADMIN SETTINGS` button and input your email
2. add a product with less than 25% inventory
3. you should get two emails, one for 25% and one for 50%
4. if you add another product without changing the current product's inventory, you should only get notified for the one you added if applicable
