### PR TITLE
fix image uploads to be put in persistent storage

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,6 +5,7 @@ env:
   STAFF_PASSWORD: password
   VOLUNTEER_PASSWORD: password
   CATEGORY_ICONS_PATH: data/category_icons
+  IMAGES_UPLOAD_PATH: data/images
 
 on:
   push:

--- a/app.py
+++ b/app.py
@@ -28,9 +28,8 @@ bcrypt = Bcrypt(app)
 
 app.config['SECRET_KEY'] = os.environ.get("APP_SECRET_KEY", "default")
 app.config["SESSION_PROTECTION"] = "strong"
-UPLOAD_FOLDER = os.path.join("static", "images")
-os.makedirs(UPLOAD_FOLDER, exist_ok=True) #NOTE: maybe remove when presistent storage gets added
-app.config['UPLOADED_IMAGES'] = UPLOAD_FOLDER
+IMAGES_UPLOAD_PATH = os.environ.get("IMAGES_UPLOAD_PATH", "/data/images/")
+os.makedirs(IMAGES_UPLOAD_PATH, exist_ok=True)
 
 def is_mobile():
     user_agent = parse(request.user_agent.string)
@@ -381,8 +380,9 @@ def post_product_upload_image(product_id: int):
         file.seek(0) # Reset file pointer after reading
 
         filename = file.filename
-        file.save(os.path.join(app.config['UPLOADED_IMAGES'], filename))
-        product.set_img_path(filename)
+        path = os.path.join(IMAGES_UPLOAD_PATH, filename)
+        file.save(path)
+        product.set_img_path(path)
         return htmx_redirect("../" + str(product_id))
     except:
         return make_response('File is not an image', 400)
@@ -753,9 +753,9 @@ def export_csv():
     response.headers["Content-Disposition"] = "attachment; filename=products.csv"
     return response
 
-@app.route("/data/category_icons/<path:filename>")
+@app.route("/data/<path:filename>")
 def serve_persisted_files(filename):
-    return send_from_directory('/data/category_icons', filename)
+    return send_from_directory('/data/', filename)
 
 with app.app_context():
     if not User.get_by_username('admin'):

--- a/fly.toml
+++ b/fly.toml
@@ -29,3 +29,4 @@ primary_region = 'sea'
   INVENTORY_DB_PATH="/data/inventory.db"
   USERS_DB_PATH="/data/users.db"
   CATEGORY_ICONS_PATH="/data/category_icons/"
+  IMAGES_UPLOAD_PATH="/data/images/"

--- a/templates/inventory_history.html
+++ b/templates/inventory_history.html
@@ -15,7 +15,7 @@
                         {% if not filepath %}
                         <img src="icons/image-camera.svg" class="upload-trigger" />
                         {% else %}
-                        <img src="images/{{ filepath }}" />
+                        <img src="{{ filepath }}" />
                         {% endif %}
                     </label>
                 </div>
@@ -87,7 +87,7 @@
 
             <form action="/product_upload_image/{{ product.get_id() }}"
                 hx-post="/product_upload_image/{{ product.get_id() }}" method="POST" enctype="multipart/form-data"
-                hx-on::after-request="alert(event.detail.xhr.responseText)" hx-target="#image-message-placeholder"
+                hx-target="#image-message-placeholder"
                 hx-swap="innerHTML">
                 <input type="file" id="fileInput" name="file" accept="image/*" required style="display: none;">
             </form>


### PR DESCRIPTION
# What does this PR implement/fix? Explain your changes.
This puts images in the persistent `/data` volume to that they are not lost when the app goes down. 

# Does this close any open issues?
closes #104

# Instructions for testing
1. Make a product
2. upload an image
3. make sure it works
