### PR TITLE
Inventory History tweaking

### DIFF
--- a/static/styles/modal.css
+++ b/static/styles/modal.css
@@ -125,7 +125,7 @@ input#donation:hover {
 }
 
 .add-category-id {
-    color: #ffffff;
+    background-color: #ffffff;
     border-color: var(--hrdc-theme-teal);
     border-radius: 5px;
     font-family: 'Gotham Book';
@@ -147,7 +147,7 @@ button#add-product-label, button#new_unit {
     padding: 1rem 1rem;
 }
 
-button.btn-danger {
+button.btn-danger, button.product-danger-button {
     background-color: #ffffff;
     border-style: none;
 }

--- a/static/styles/product_page.css
+++ b/static/styles/product_page.css
@@ -32,6 +32,7 @@ canvas {
 .mobile-form-control, .mobile-form-container, .mobile-select {
     margin: 0;
     width: 100%;
+    color: var(--hrdc-theme-teal);
 }
 .mobile-select {
     margin-top: 10px;
@@ -46,13 +47,13 @@ canvas {
 }
 .back-link {
     text-decoration: none;
-    color: var(--hrdc-theme-dark-teal);
+    color: var(--hrdc-theme-teal);
     margin-bottom: 10px;
-    border: 1px solid currentColor;
-    border-radius: 3px;
+    border: none;
 }
 .back-link:hover {
-    background-color: var(--hrdc-theme-light-grey);
+    background-color: var(--hrdc-theme-green-yellow);
+    color: white;
 }
 
 .image-box {
@@ -106,7 +107,7 @@ canvas {
     text-transform: uppercase;
 }
 .product-action-inventory:hover {
-    background-color: var(--hrdc-theme-dark-teal);
+    background-color: var(--hrdc-theme-green-yellow);
 }
 
 .product-action-more {
@@ -183,6 +184,7 @@ canvas {
     display: flex;
     align-items: center;
     margin: 11px 0;
+    color: var(--hrdc-theme-dark-teal);
 }
 .info-row > span {
     flex-shrink: 0;
@@ -192,6 +194,12 @@ canvas {
     width: 100%;
     border-top: 2px dotted var(--hrdc-theme-medium-grey);
     margin: 0 8px;
+}
+
+tr#info-col
+{
+    color: var(--hrdc-theme-dark-teal);
+    text-indent: 10px;
 }
 
 .timeframe-form > *:not(label) {

--- a/static/styles/settings.css
+++ b/static/styles/settings.css
@@ -36,7 +36,8 @@
 
 .admin-back a:hover
 {
-    color: var(--hrdc-theme-green-yellow);
+    color: white;
+    background-color: var(--hrdc-theme-green-yellow);
     cursor: pointer;
 }
 

--- a/templates/inventory_history.html
+++ b/templates/inventory_history.html
@@ -319,7 +319,7 @@
     </div>
     <div class="box-shadow-small" style="grid-column: 3;">
         <table><tbody>
-            <tr>
+            <tr id="info-col">
                 <th>Unit Name</th>
                 <th>Individual/Unit</th>
                 <th>Price/Unit</th>

--- a/templates/modals/product_update_stock.html
+++ b/templates/modals/product_update_stock.html
@@ -8,7 +8,7 @@
 		<form hx-post="product_update_inventory/{{ product.get_id() }}" hx-target="#modal-errors" hx-swap="innerHTML">
 			{{ form.csrf_token }}
 			<input type="hidden" name="_method" value="PATCH">
-
+			
 			{% include "modals/stock_unit_add_update.html" %}
 			<br>
 			<br>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -5,7 +5,10 @@
 
 
 <header>
-    <div class="admin-back"><img alt="Go Back" src="icons/arrow_left.svg"><a href="/">BACK</a></div>
+    <div class="admin-back">
+        <a style="position: relative;" href="/">
+            <img style="position: relative; top: 6px;" src="icons/arrow_left.svg" alt="Left Arrow"/>Back to Home
+        </a></div>
 </header>
 <body>
     <div style="margin-left: 10px">


### PR DESCRIPTION
# What does this PR implement/fix? Explain your changes.

changes in Inventory History:
- changed the back button to make it consistent with the back button in admin settings
- fixed the X button for Set Inventory and Add Inventory
- changed information to the right of Lifetime (Unit Name, Individual/Unit, etc)  to be colored and indented properly
- changed information below the Set Inventory and Add Inventory to be colored properly
- Set Inventory and Add Inventory has the green-yellow highlight like the other buttons

changes in Admin Settings:
- admin settings back button set from "BACK" to "Back To Home"

changes in New Product Modal:
- changed the Category selection background from gray to white

# Does this close any open issues?

nope :D

# Instructions for testing

1. login
2. go to inventory history
3. make sure the "back to home" button has a green-yellow highlight
4. make sure the "set inventory" and "add inventory" buttons have the green-yellow highlight
5. make sure the "set inventory" and "add inventory" modals have the white-colored X button (no gray button around the X)
6. check the spacing for the information to the right of Lifetime
7. make sure the Category selection background in New Product is not gray but is white
8. logout
